### PR TITLE
tests: Fix tests using a different region than default

### DIFF
--- a/src/terraform-resource/check/check_test.go
+++ b/src/terraform-resource/check/check_test.go
@@ -65,6 +65,7 @@ var _ = Describe("Check", func() {
 					BucketPath:      bucketPath,
 					AccessKeyID:     accessKey,
 					SecretAccessKey: secretKey,
+					RegionName:      region,
 				},
 			},
 		}

--- a/src/terraform-resource/in/in_test.go
+++ b/src/terraform-resource/in/in_test.go
@@ -66,6 +66,7 @@ var _ = Describe("In", func() {
 					BucketPath:      bucketPath,
 					AccessKeyID:     accessKey,
 					SecretAccessKey: secretKey,
+					RegionName:      region,
 				},
 			},
 		}

--- a/src/terraform-resource/out/out_lifecycle_test.go
+++ b/src/terraform-resource/out/out_lifecycle_test.go
@@ -59,6 +59,7 @@ var _ = Describe("Out Lifecycle", func() {
 					BucketPath:      bucketPath,
 					AccessKeyID:     accessKey,
 					SecretAccessKey: secretKey,
+					RegionName:      region,
 				},
 			},
 			Params: models.OutParams{
@@ -71,6 +72,7 @@ var _ = Describe("Out Lifecycle", func() {
 						"bucket":         bucket,
 						"object_key":     s3ObjectPath,
 						"object_content": "terraform-is-neat",
+						"region":         region,
 					},
 				},
 			},
@@ -126,6 +128,7 @@ var _ = Describe("Out Lifecycle", func() {
 			"access_key":     accessKey,
 			"secret_key":     secretKey,
 			"object_content": "terraform-is-still-neat",
+			"region":         region,
 		}
 		updateOutput, err := runner.Run(outRequest)
 		Expect(err).ToNot(HaveOccurred())

--- a/src/terraform-resource/out/out_test.go
+++ b/src/terraform-resource/out/out_test.go
@@ -39,6 +39,10 @@ var _ = Describe("Out", func() {
 	)
 
 	BeforeEach(func() {
+		region := os.Getenv("AWS_REGION") // optional
+		if region == "" {
+			region = "us-east-1"
+		}
 		envName = helpers.RandomString("out-test")
 		stateFilePath = path.Join(bucketPath, fmt.Sprintf("%s.tfstate", envName))
 		s3ObjectPath = path.Join(bucketPath, helpers.RandomString("out-test"))
@@ -48,6 +52,7 @@ var _ = Describe("Out", func() {
 			BucketPath:      bucketPath,
 			AccessKeyID:     accessKey,
 			SecretAccessKey: secretKey,
+			RegionName:      region,
 		}
 
 		var err error
@@ -89,6 +94,7 @@ var _ = Describe("Out", func() {
 						"bucket":         bucket,
 						"object_key":     s3ObjectPath,
 						"object_content": "terraform-is-neat",
+						"region":         region,
 					},
 				},
 			},
@@ -117,6 +123,7 @@ var _ = Describe("Out", func() {
 						"bucket":         bucket,
 						"object_key":     s3ObjectPath,
 						"object_content": "terraform-is-neat",
+						"region":         region,
 					},
 				},
 			},
@@ -144,6 +151,7 @@ var _ = Describe("Out", func() {
 						"bucket":         bucket,
 						"object_key":     s3ObjectPath,
 						"object_content": "terraform-is-neat",
+						"region":         region,
 					},
 				},
 			},
@@ -168,6 +176,7 @@ var _ = Describe("Out", func() {
 						"bucket":         bucket,
 						"object_key":     s3ObjectPath,
 						"object_content": "terraform-is-neat",
+						"region":         region,
 					},
 				},
 			},
@@ -192,6 +201,7 @@ var _ = Describe("Out", func() {
 					Vars: map[string]interface{}{
 						"access_key": accessKey,
 						"secret_key": "bad-secret-key", // will be overridden
+						"region":     region,
 					},
 				},
 			},
@@ -204,6 +214,7 @@ var _ = Describe("Out", func() {
 						"bucket":         bucket,
 						"object_key":     s3ObjectPath,
 						"object_content": "terraform-is-neat",
+						"region":         region,
 					},
 				},
 			},
@@ -248,6 +259,7 @@ var _ = Describe("Out", func() {
 							"access_key": accessKey,
 							// will be overridden
 							"secret_key": "bad-secret-key",
+							"region":     region,
 						},
 					},
 				},
@@ -259,6 +271,7 @@ var _ = Describe("Out", func() {
 							"secret_key": secretKey,
 							// will be overridden
 							"object_content": "to-be-overridden",
+							"region":         region,
 						},
 						// var file overrides put.params
 						VarFile: varFileName,
@@ -289,6 +302,7 @@ var _ = Describe("Out", func() {
 						"bucket":         bucket,
 						"object_key":     s3ObjectPath,
 						"object_content": "terraform-is-neat",
+						"region":         region,
 					},
 				},
 			},
@@ -317,6 +331,7 @@ var _ = Describe("Out", func() {
 						"bucket":         bucket,
 						"object_key":     s3ObjectPath,
 						"object_content": "terraform-is-neat",
+						"region":         region,
 					},
 				},
 			},
@@ -345,6 +360,7 @@ var _ = Describe("Out", func() {
 						"bucket":         bucket,
 						"object_key":     s3ObjectPath,
 						"object_content": "terraform-is-neat",
+						"region":         region,
 					},
 				},
 			},
@@ -389,6 +405,7 @@ var _ = Describe("Out", func() {
 							"bucket":         bucket,
 							"object_key":     s3ObjectPath,
 							"object_content": "terraform-is-neat",
+							"region":         region,
 						},
 					},
 				},
@@ -418,6 +435,7 @@ var _ = Describe("Out", func() {
 						"bucket":         bucket,
 						"object_key":     s3ObjectPath,
 						"object_content": "terraform-is-neat",
+						"region":         region,
 					},
 				},
 			},
@@ -447,6 +465,7 @@ var _ = Describe("Out", func() {
 						"bucket":         bucket,
 						"object_key":     s3ObjectPath,
 						"object_content": "terraform-is-neat",
+						"region":         region,
 					},
 				},
 			},
@@ -481,6 +500,7 @@ var _ = Describe("Out", func() {
 						"bucket":         bucket,
 						"object_key":     s3ObjectPath,
 						"object_content": "terraform-is-neat",
+						"region":         region,
 					},
 				},
 			},
@@ -525,6 +545,7 @@ var _ = Describe("Out", func() {
 							"bucket":         bucket,
 							"object_key":     s3ObjectPath,
 							"object_content": "terraform-is-neat",
+							"region":         region,
 						},
 					},
 				},
@@ -562,6 +583,7 @@ var _ = Describe("Out", func() {
 							"object_key":           s3ObjectPath,
 							"object_content":       "terraform-is-neat",
 							"invalid_object_count": "1",
+							"region":               region,
 						},
 					},
 				},
@@ -647,12 +669,13 @@ var _ = Describe("Out", func() {
 				BucketPath:      bucketPath,
 				AccessKeyID:     s3CompatibleAccessKey,
 				SecretAccessKey: s3CompatibleSecretKey,
+				RegionName:      region,
 			}
 
 			s3Verifier = helpers.NewAWSVerifier(
 				s3CompatibleAccessKey,
 				s3CompatibleSecretKey,
-				"",
+				region,
 				s3CompatibleEndpoint,
 			)
 		})
@@ -676,6 +699,7 @@ var _ = Describe("Out", func() {
 							"bucket":         bucket,
 							"object_key":     s3ObjectPath,
 							"object_content": "terraform-is-neat",
+							"region":         region,
 						},
 					},
 				},


### PR DESCRIPTION
Most of the tests were using the default "us-east-1" region and didn't use the AWS_REGION env variable. This pr fix this behavior