### PR TITLE
Adding plan feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,31 @@ Finally, `env_name` is automatically passed as an input `var`.
           remove: locks/
 ```
 
+#### Plan and apply example
+
+```yaml
+- name: terraform-plan
+   plan:
+      - put: terraform
+        params:
+          env_name: staging
+          plan_only: true
+          vars:
+            subnet_cidr: 10.0.1.0/24
+
+- name: terraform-apply
+  plan:
+      - get: terraform
+        trigger: false
+        passed: [terraform-plan]
+      - put: terraform
+        params:
+          env_name: staging
+          run_plan: true
+          vars:
+            subnet_cidr: 10.0.1.0/24
+```
+
 #### Metadata file
 
 Every `put` action creates `name` and `metadata` files as an output containing the `env_name` and [Terraform Outputs](https://www.terraform.io/intro/getting-started/outputs.html) in JSON format.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Finally, `env_name` is automatically passed as an input `var`.
 
 * `generate_random_name`: *Optional.* Generates a random `env_name` (e.g. "coffee-bee"). Useful for creating lock files.
 
+* `plan_only`: *Optional.* This boolean will allow terraform to create a plan file and store it on S3.
+
+* `plan_run`: *Optional.* This boolean will allow terraform to execute the plan file stored on S3, then delete it.
+
 * `env_name_file`: *Optional.* Reads the `env_name` from a specified file path. Useful for destroying environments from a lock file.
 
 * `action`: *Optional.* Used to indicate a destructive `put`. The only recognized value is `destroy`, create / update are the implicit defaults.
@@ -172,7 +176,7 @@ Finally, `env_name` is automatically passed as an input `var`.
       - put: terraform
         params:
           env_name: staging
-          run_plan: true
+          plan_run: true
           vars:
             subnet_cidr: 10.0.1.0/24
 ```

--- a/src/terraform-resource/models/out.go
+++ b/src/terraform-resource/models/out.go
@@ -14,8 +14,11 @@ type OutParams struct {
 	EnvName            string `json:"env_name"`
 	EnvNameFile        string `json:"env_name_file"`
 	GenerateRandomName bool   `json:"generate_random_name"`
+	PlanOnly           bool   `json:"plan_only,omitempty"`  // optional
+	RunPlan            bool   `json:"run_plan,omitempty"`   // optional
+	Action             string `json:"action,omitempty"`     // optional
 	Terraform
-	Action string `json:"action,omitempty"` // optional
+
 }
 
 const (

--- a/src/terraform-resource/models/out.go
+++ b/src/terraform-resource/models/out.go
@@ -14,11 +14,10 @@ type OutParams struct {
 	EnvName            string `json:"env_name"`
 	EnvNameFile        string `json:"env_name_file"`
 	GenerateRandomName bool   `json:"generate_random_name"`
-	PlanOnly           bool   `json:"plan_only,omitempty"`  // optional
-	RunPlan            bool   `json:"run_plan,omitempty"`   // optional
-	Action             string `json:"action,omitempty"`     // optional
+	PlanOnly           bool   `json:"plan_only,omitempty"` // optional
+	PlanRun            bool   `json:"plan_run,omitempty"`  // optional
+	Action             string `json:"action,omitempty"`    // optional
 	Terraform
-
 }
 
 const (

--- a/src/terraform-resource/models/terraform.go
+++ b/src/terraform-resource/models/terraform.go
@@ -13,7 +13,7 @@ type Terraform struct {
 	Vars                map[string]interface{} `json:"vars,omitempty"`              // optional
 	VarFile             string                 `json:"var_file,omitempty"`          // optional
 	DeleteOnFailure     bool                   `json:"delete_on_failure,omitempty"` // optional
-	RunPlan             bool                   `json:"run_plan,omitempty"`          // optional
+	PlanRun             bool                   `json:"plan_run,omitempty"`          // optional
 	PlanFileLocalPath   string                 `json:"-"`                           // not specified pipeline
 	PlanFileRemotePath  string                 `json:"-"`                           // not specified pipeline
 	StateFileLocalPath  string                 `json:"-"`                           // not specified pipeline

--- a/src/terraform-resource/models/terraform.go
+++ b/src/terraform-resource/models/terraform.go
@@ -13,6 +13,9 @@ type Terraform struct {
 	Vars                map[string]interface{} `json:"vars,omitempty"`              // optional
 	VarFile             string                 `json:"var_file,omitempty"`          // optional
 	DeleteOnFailure     bool                   `json:"delete_on_failure,omitempty"` // optional
+	RunPlan             bool                   `json:"run_plan,omitempty"`          // optional
+	PlanFileLocalPath   string                 `json:"-"`                           // not specified pipeline
+	PlanFileRemotePath  string                 `json:"-"`                           // not specified pipeline
 	StateFileLocalPath  string                 `json:"-"`                           // not specified pipeline
 	StateFileRemotePath string                 `json:"-"`                           // not specified pipeline
 }
@@ -46,6 +49,12 @@ func (m Terraform) Merge(other Terraform) Terraform {
 	}
 	if other.VarFile != "" {
 		m.VarFile = other.VarFile
+	}
+	if other.PlanFileLocalPath != "" {
+		m.PlanFileLocalPath = other.PlanFileLocalPath
+	}
+	if other.PlanFileRemotePath != "" {
+		m.PlanFileRemotePath = other.PlanFileRemotePath
 	}
 	if other.StateFileLocalPath != "" {
 		m.StateFileLocalPath = other.StateFileLocalPath

--- a/src/terraform-resource/models/version.go
+++ b/src/terraform-resource/models/version.go
@@ -18,6 +18,7 @@ const (
 type Version struct {
 	LastModified string `json:"last_modified"`
 	EnvName      string `json:"env_name"`
+	PlanOnly     bool   `json:"plan_only,omitempty"`  //optional
 }
 
 func NewVersion(storageVersion storage.Version) Version {
@@ -26,6 +27,7 @@ func NewVersion(storageVersion storage.Version) Version {
 	return Version{
 		LastModified: storageVersion.LastModified.Format(TimeFormat),
 		EnvName:      envName,
+		PlanOnly:     false,
 	}
 }
 
@@ -56,6 +58,10 @@ func (r Version) Validate() error {
 
 func (r Version) IsZero() bool {
 	return r == Version{}
+}
+
+func (r Version) IsPlan() bool {
+	return r.PlanOnly
 }
 
 func (r Version) LastModifiedTime() time.Time {

--- a/src/terraform-resource/out/out_lifecycle_test.go
+++ b/src/terraform-resource/out/out_lifecycle_test.go
@@ -175,4 +175,43 @@ var _ = Describe("Out Lifecycle", func() {
 		Expect(deletedVersion).To(BeTemporally(">", updatedVersion))
 		Expect(deleteOutput.Version.EnvName).To(Equal(outRequest.Params.EnvName))
 	})
+
+	It("plan infrastructure", func() {
+		planOutRequest := models.OutRequest{
+			Source: models.Source{
+				Storage: storage.Model{
+					Bucket:          bucket,
+					BucketPath:      bucketPath,
+					AccessKeyID:     accessKey,
+					SecretAccessKey: secretKey,
+					RegionName:      region,
+				},
+			},
+			Params: models.OutParams{
+				PlanOnly: true,
+				EnvName: envName,
+				Terraform: models.Terraform{
+					Source: "fixtures/aws/",
+					Vars: map[string]interface{}{
+						"access_key":     accessKey,
+						"secret_key":     secretKey,
+						"bucket":         bucket,
+						"object_key":     s3ObjectPath,
+						"object_content": "terraform-is-neat",
+						"region":         region,
+					},
+				},
+			},
+		}
+
+		By("running 'out' to create the plan file")
+
+		planRunner := out.Runner{
+			SourceDir: workingDir,
+			LogWriter: GinkgoWriter,
+		}
+		_, err := planRunner.Run(planOutRequest)
+		Expect(err).ToNot(HaveOccurred())
+
+	})
 })

--- a/src/terraform-resource/out/out_plan_test.go
+++ b/src/terraform-resource/out/out_plan_test.go
@@ -1,0 +1,395 @@
+package out_test
+
+import (
+	"crypto/md5"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"time"
+
+	"terraform-resource/models"
+	"terraform-resource/out"
+	"terraform-resource/storage"
+	"terraform-resource/test/helpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Out Plan", func() {
+
+	var (
+		envName       string
+		stateFilePath string
+		planFilePath  string
+		s3ObjectPath  string
+		workingDir    string
+	)
+
+	BeforeEach(func() {
+		envName = helpers.RandomString("out-test")
+		stateFilePath = path.Join(bucketPath, fmt.Sprintf("%s.tfstate", envName))
+		planFilePath = path.Join(bucketPath, fmt.Sprintf("%s.plan", envName))
+		s3ObjectPath = path.Join(bucketPath, helpers.RandomString("out-plan"))
+
+		var err error
+		workingDir, err = ioutil.TempDir(os.TempDir(), "terraform-resource-out-plan-test")
+		Expect(err).ToNot(HaveOccurred())
+
+		// ensure relative paths resolve correctly
+		err = os.Chdir(workingDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		fixturesDir := path.Join(helpers.ProjectRoot(), "fixtures")
+		err = exec.Command("cp", "-r", fixturesDir, workingDir).Run()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(workingDir)
+		awsVerifier.DeleteObjectFromS3(bucket, s3ObjectPath)
+		awsVerifier.DeleteObjectFromS3(bucket, stateFilePath)
+		awsVerifier.DeleteObjectFromS3(bucket, planFilePath)
+	})
+
+	It("plan infrastructure and apply it", func() {
+		planOutRequest := models.OutRequest{
+			Source: models.Source{
+				Storage: storage.Model{
+					Bucket:          bucket,
+					BucketPath:      bucketPath,
+					AccessKeyID:     accessKey,
+					SecretAccessKey: secretKey,
+					RegionName:      region,
+				},
+			},
+			Params: models.OutParams{
+				PlanOnly: true,
+				EnvName:  envName,
+				Terraform: models.Terraform{
+					Source: "fixtures/aws/",
+					Vars: map[string]interface{}{
+						"access_key":     accessKey,
+						"secret_key":     secretKey,
+						"bucket":         bucket,
+						"object_key":     s3ObjectPath,
+						"object_content": "terraform-is-neat",
+						"region":         region,
+					},
+				},
+			},
+		}
+
+		applyRequest := models.OutRequest{
+			Source: models.Source{
+				Storage: storage.Model{
+					Bucket:          bucket,
+					BucketPath:      bucketPath,
+					AccessKeyID:     accessKey,
+					SecretAccessKey: secretKey,
+					RegionName:      region,
+				},
+			},
+			Params: models.OutParams{
+				PlanRun: true,
+				EnvName: envName,
+				Terraform: models.Terraform{
+					Source: "fixtures/aws/",
+					Vars: map[string]interface{}{
+						"access_key":     accessKey,
+						"secret_key":     secretKey,
+						"bucket":         bucket,
+						"object_key":     s3ObjectPath,
+						"object_content": "terraform-is-neat",
+						"region":         region,
+					},
+				},
+			},
+		}
+
+		By("ensuring plan file does not already exist")
+
+		awsVerifier.ExpectS3FileToNotExist(
+			planOutRequest.Source.Storage.Bucket,
+			planFilePath,
+		)
+
+		By("running 'out' to create the plan file")
+
+		planrunner := out.Runner{
+			SourceDir: workingDir,
+			LogWriter: GinkgoWriter,
+		}
+		planOutput, err := planrunner.Run(planOutRequest)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("ensuring that plan file exists with valid version (LastModified)")
+
+		awsVerifier.ExpectS3FileToExist(
+			planOutRequest.Source.Storage.Bucket,
+			planFilePath,
+		)
+
+		_, err = time.Parse(storage.TimeFormat, planOutput.Version.LastModified)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(planOutput.Version.EnvName).To(Equal(planOutRequest.Params.EnvName))
+
+		time.Sleep(1 * time.Second) // ensure LastModified changes
+
+		By("ensuring state file does not already exist")
+
+		awsVerifier.ExpectS3FileToNotExist(
+			applyRequest.Source.Storage.Bucket,
+			stateFilePath,
+		)
+
+		By("applying the plan")
+
+		applyrunner := out.Runner{
+			SourceDir: workingDir,
+			LogWriter: GinkgoWriter,
+		}
+		createOutput, err := applyrunner.Run(applyRequest)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(createOutput.Metadata).ToNot(BeEmpty())
+		fields := map[string]interface{}{}
+		for _, field := range createOutput.Metadata {
+			fields[field.Name] = field.Value
+		}
+		Expect(fields["env_name"]).To(Equal(envName))
+		expectedMD5 := fmt.Sprintf("%x", md5.Sum([]byte("terraform-is-neat")))
+		Expect(fields["content_md5"]).To(Equal(expectedMD5))
+
+		awsVerifier.ExpectS3FileToExist(
+			applyRequest.Source.Storage.Bucket,
+			s3ObjectPath,
+		)
+
+		By("ensuring that plan file no longer exists after the apply")
+
+		awsVerifier.ExpectS3FileToNotExist(
+			applyRequest.Source.Storage.Bucket,
+			planFilePath,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+
+	It("takes the existing statefile into account when generating a plan", func() {
+		initialApplyRequest := models.OutRequest{
+			Source: models.Source{
+				Storage: storage.Model{
+					Bucket:          bucket,
+					BucketPath:      bucketPath,
+					AccessKeyID:     accessKey,
+					SecretAccessKey: secretKey,
+					RegionName:      region,
+				},
+			},
+			Params: models.OutParams{
+				EnvName: envName,
+				Terraform: models.Terraform{
+					Source: "fixtures/aws/",
+					Vars: map[string]interface{}{
+						"access_key":     accessKey,
+						"secret_key":     secretKey,
+						"bucket":         bucket,
+						"object_key":     s3ObjectPath,
+						"object_content": "terraform-is-neat",
+						"region":         region,
+					},
+				},
+			},
+		}
+
+		planRequest := models.OutRequest{
+			Source: models.Source{
+				Storage: storage.Model{
+					Bucket:          bucket,
+					BucketPath:      bucketPath,
+					AccessKeyID:     accessKey,
+					SecretAccessKey: secretKey,
+					RegionName:      region,
+				},
+			},
+			Params: models.OutParams{
+				PlanOnly: true,
+				EnvName:  envName,
+				Terraform: models.Terraform{
+					Source: "fixtures/aws/",
+					Vars: map[string]interface{}{
+						"access_key":     accessKey,
+						"secret_key":     secretKey,
+						"bucket":         bucket,
+						"object_key":     s3ObjectPath,
+						"object_content": "terraform-is-neat",
+						"region":         region,
+					},
+				},
+			},
+		}
+
+		applyPlanRequest := models.OutRequest{
+			Source: models.Source{
+				Storage: storage.Model{
+					Bucket:          bucket,
+					BucketPath:      bucketPath,
+					AccessKeyID:     accessKey,
+					SecretAccessKey: secretKey,
+					RegionName:      region,
+				},
+			},
+			Params: models.OutParams{
+				PlanRun: true,
+				EnvName: envName,
+				Terraform: models.Terraform{
+					Source: "fixtures/aws/",
+					Vars: map[string]interface{}{
+						"access_key":     accessKey,
+						"secret_key":     secretKey,
+						"bucket":         bucket,
+						"object_key":     s3ObjectPath,
+						"object_content": "terraform-is-neat",
+						"region":         region,
+					},
+				},
+			},
+		}
+
+		By("ensuring plan and state files does not already exist")
+
+		awsVerifier.ExpectS3FileToNotExist(
+			initialApplyRequest.Source.Storage.Bucket,
+			stateFilePath,
+		)
+		awsVerifier.ExpectS3FileToNotExist(
+			initialApplyRequest.Source.Storage.Bucket,
+			planFilePath,
+		)
+
+		By("running 'out' to create the statefile")
+
+		runner := out.Runner{
+			SourceDir: workingDir,
+			LogWriter: GinkgoWriter,
+		}
+		_, err := runner.Run(initialApplyRequest)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("ensuring that statefile exists and plan does not")
+
+		awsVerifier.ExpectS3FileToExist(
+			bucket,
+			stateFilePath,
+		)
+		awsVerifier.ExpectS3FileToNotExist(
+			bucket,
+			planFilePath,
+		)
+
+		initialLastModified := awsVerifier.GetLastModifiedFromS3(bucket, s3ObjectPath)
+
+		time.Sleep(1 * time.Second) // ensure LastModified has time to change
+
+		By("creating the plan")
+
+		_, err = runner.Run(planRequest)
+		Expect(err).ToNot(HaveOccurred())
+
+		awsVerifier.ExpectS3FileToExist(
+			bucket,
+			s3ObjectPath,
+		)
+
+		By("ensuring that state and plan files exist")
+
+		awsVerifier.ExpectS3FileToExist(
+			bucket,
+			stateFilePath,
+		)
+		awsVerifier.ExpectS3FileToExist(
+			bucket,
+			planFilePath,
+		)
+
+		By("applying the plan")
+
+		_, err = runner.Run(applyPlanRequest)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("ensuring that existing statefile was used and S3 Object was unchanged")
+		finalLastModified := awsVerifier.GetLastModifiedFromS3(bucket, s3ObjectPath)
+		Expect(finalLastModified).To(Equal(initialLastModified))
+	})
+
+	It("plan should be deleted on destroy", func() {
+		planOutRequest := models.OutRequest{
+			Source: models.Source{
+				Storage: storage.Model{
+					Bucket:          bucket,
+					BucketPath:      bucketPath,
+					AccessKeyID:     accessKey,
+					SecretAccessKey: secretKey,
+					RegionName:      region,
+				},
+			},
+			Params: models.OutParams{
+				PlanOnly: true,
+				EnvName:  envName,
+				Terraform: models.Terraform{
+					Source: "fixtures/aws/",
+					Vars: map[string]interface{}{
+						"access_key":     accessKey,
+						"secret_key":     secretKey,
+						"bucket":         bucket,
+						"object_key":     s3ObjectPath,
+						"object_content": "terraform-is-neat",
+						"region":         region,
+					},
+				},
+			},
+		}
+
+		By("ensuring state and plan file does not already exist")
+
+		awsVerifier.ExpectS3FileToNotExist(
+			planOutRequest.Source.Storage.Bucket,
+			planFilePath,
+		)
+
+		By("running 'out' to create the plan file")
+
+		planrunner := out.Runner{
+			SourceDir: workingDir,
+			LogWriter: GinkgoWriter,
+		}
+		_, err := planrunner.Run(planOutRequest)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("ensuring that plan file exists with valid version (LastModified)")
+
+		awsVerifier.ExpectS3FileToExist(
+			planOutRequest.Source.Storage.Bucket,
+			planFilePath,
+		)
+
+		By("running 'out' to delete the plan file")
+
+		planOutRequest.Params.PlanOnly = false
+		planOutRequest.Params.Action = models.DestroyAction
+		_, err = planrunner.Run(planOutRequest)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("ensuring that plan file no longer exists")
+
+		awsVerifier.ExpectS3FileToNotExist(
+			planOutRequest.Source.Storage.Bucket,
+			planFilePath,
+		)
+
+	})
+
+})

--- a/src/terraform-resource/storage/models.go
+++ b/src/terraform-resource/storage/models.go
@@ -29,6 +29,7 @@ type Model struct {
 type Version struct {
 	LastModified time.Time
 	StateFile    string
+	PlanFile     string
 }
 
 func (m Model) Validate() error {

--- a/src/terraform-resource/terraform/action.go
+++ b/src/terraform-resource/terraform/action.go
@@ -135,6 +135,10 @@ func (a Action) attemptDestroy() (Result, error) {
 		return Result{}, err
 	}
 
+	_, err := a.PlanFile.Delete()
+	if err != nil {
+		return Result{}, err
+	}
 	storageVersion, err := a.StateFile.Delete()
 	if err != nil {
 		return Result{}, err

--- a/src/terraform-resource/terraform/client.go
+++ b/src/terraform-resource/terraform/client.go
@@ -50,7 +50,7 @@ func (c Client) Apply() error {
 		"-backup='-'",  // no need to backup state file
 		"-input=false", // do not prompt for inputs
 	}
-	if c.Model.RunPlan {
+	if c.Model.PlanRun {
 		applyArgs = append(applyArgs, fmt.Sprintf("%s", c.Model.PlanFileLocalPath))
 	} else {
 		applyArgs = append(applyArgs, fmt.Sprintf("-state=%s", c.Model.StateFileLocalPath))

--- a/src/terraform-resource/terraform/client.go
+++ b/src/terraform-resource/terraform/client.go
@@ -49,8 +49,13 @@ func (c Client) Apply() error {
 		"apply",
 		"-backup='-'",  // no need to backup state file
 		"-input=false", // do not prompt for inputs
-		fmt.Sprintf("-state=%s", c.Model.StateFileLocalPath),
 	}
+	if c.Model.RunPlan {
+		applyArgs = append(applyArgs, fmt.Sprintf("%s", c.Model.PlanFileLocalPath))
+	} else {
+		applyArgs = append(applyArgs, fmt.Sprintf("-state=%s", c.Model.StateFileLocalPath))
+	}
+
 	applyArgs = append(applyArgs, c.varFlags()...)
 	applyArgs = append(applyArgs, tmpDir)
 
@@ -103,6 +108,51 @@ func (c Client) Destroy() error {
 	destroyCmd.Stdout = c.LogWriter
 	destroyCmd.Stderr = c.LogWriter
 	err = destroyCmd.Run()
+	if err != nil {
+		return fmt.Errorf("Failed to run Terraform command: %s", err)
+	}
+
+	return nil
+}
+
+func (c Client) Plan() error {
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "terraform-resource-client")
+	if err != nil {
+		return fmt.Errorf("Failed to create temporary working dir at '%s'", os.TempDir())
+	}
+	defer os.RemoveAll(tmpDir)
+
+	initCmd := terraformCmd([]string{
+		"init",
+		c.Model.Source,
+		tmpDir,
+	})
+	if initOutput, initErr := initCmd.CombinedOutput(); initErr != nil {
+		return fmt.Errorf("terraform init command failed.\nError: %s\nOutput: %s", initErr, initOutput)
+	}
+
+	getCmd := terraformCmd([]string{
+		"get",
+		"-update",
+		tmpDir,
+	})
+	if getOutput, getErr := getCmd.CombinedOutput(); getErr != nil {
+		return fmt.Errorf("terraform get command failed.\nError: %s\nOutput: %s", getErr, getOutput)
+	}
+
+	planArgs := []string{
+		"plan",
+		"-input=false", // do not prompt for inputs
+		fmt.Sprintf("-out=%s", c.Model.PlanFileLocalPath),
+		fmt.Sprintf("-state=%s", c.Model.StateFileLocalPath),
+	}
+	planArgs = append(planArgs, c.varFlags()...)
+	planArgs = append(planArgs, tmpDir)
+
+	planCmd := terraformCmd(planArgs)
+	planCmd.Stdout = c.LogWriter
+	planCmd.Stderr = c.LogWriter
+	err = planCmd.Run()
 	if err != nil {
 		return fmt.Errorf("Failed to run Terraform command: %s", err)
 	}

--- a/src/terraform-resource/terraform/planfile.go
+++ b/src/terraform-resource/terraform/planfile.go
@@ -1,0 +1,78 @@
+package terraform
+
+import (
+	"fmt"
+	"os"
+	"terraform-resource/storage"
+	"time"
+)
+
+type PlanFile struct {
+	LocalPath     string
+	RemotePath    string
+	StorageDriver storage.Storage
+}
+
+func (p PlanFile) Exists() (bool, error) {
+	version, err := p.StorageDriver.Version(p.RemotePath)
+	if err != nil {
+		return false, fmt.Errorf("Failed to check for existing plan file from '%s': %s", p.RemotePath, err)
+	}
+	return version.IsZero() == false, nil
+}
+
+func (p PlanFile) LatestVersion() (storage.Version, error) {
+	return p.StorageDriver.LatestVersion(`.*\.tfplan$`)
+}
+
+func (p PlanFile) Download() (storage.Version, error) {
+	planFile, createErr := os.Create(p.LocalPath)
+	if createErr != nil {
+		return storage.Version{}, fmt.Errorf("Failed to create plan file at '%s': %s", p.LocalPath, createErr)
+	}
+	defer planFile.Close()
+
+	version, err := p.StorageDriver.Download(p.RemotePath, planFile)
+	if err != nil {
+		return storage.Version{}, err
+	}
+	planFile.Close()
+
+	return version, nil
+}
+
+func (p PlanFile) Upload() (storage.Version, error) {
+	planFile, err := os.Open(p.LocalPath)
+	if err != nil {
+		return storage.Version{}, fmt.Errorf("Failed to open plan file at '%s'", p.LocalPath)
+	}
+	defer planFile.Close()
+
+	_, err = p.StorageDriver.Upload(p.RemotePath, planFile)
+	if err != nil {
+		return storage.Version{}, fmt.Errorf("Failed to upload plan file: %s", err)
+	}
+
+	version, err := p.StorageDriver.Version(p.RemotePath)
+	if err != nil {
+		return storage.Version{}, fmt.Errorf("Failed to retrieve version from '%s': %s", p.RemotePath, err)
+	}
+	if version.IsZero() {
+		return storage.Version{}, fmt.Errorf("Couldn't find plan file at: %s", p.RemotePath)
+	}
+
+	return version, nil
+}
+
+func (p PlanFile) Delete() (storage.Version, error) {
+	if err := p.StorageDriver.Delete(p.RemotePath); err != nil {
+		return storage.Version{}, fmt.Errorf("Failed to delete plan file: %s", err)
+	}
+
+	// use current time rather than plan file LastModified time
+	version := storage.Version{
+		LastModified: time.Now().UTC(),
+		PlanFile:     p.RemotePath,
+	}
+	return version, nil
+}


### PR DESCRIPTION
This PR fix the issue #10 

It's currently a work in progress and will be rebased once everything will be ok.

It add two parameters : `plan_only` and `plan_run`.
The goal is to be able to output the plan in a job, then apply it (after an approval for example) in another.

It would be used like this :

``` yaml
 - name: terraform-plan
   plan:
      - put: terraform
        params:
          env_name: staging
          plan_only: true
          vars:
            subnet_cidr: 10.0.1.0/24

- name: terraform-apply
  plan:
      - get: terraform
        trigger: false
        passed: [terraform-plan]
      - put: terraform
        params:
          env_name: staging
          plan_run: true
          vars:
            subnet_cidr: 10.0.1.0/24
```
