### PR TITLE
Add build information as terraform variables

### DIFF
--- a/fixtures/aws/outputs.tf
+++ b/fixtures/aws/outputs.tf
@@ -1,6 +1,24 @@
 output "env_name" {
     value = "${var.env_name}"
 }
+output "build_id" {
+    value = "${var.build_id}"
+}
+output "build_name" {
+    value = "${var.build_name}"
+}
+output "build_job_name" {
+    value = "${var.build_job_name}"
+}
+output "build_pipeline_name" {
+    value = "${var.build_pipeline_name}"
+}
+output "build_team_name" {
+    value = "${var.build_team_name}"
+}
+output "atc_external_url" {
+    value = "${var.atc_external_url}"
+}
 output "bucket" {
     value = "${var.bucket}"
 }

--- a/fixtures/aws/variables.tf
+++ b/fixtures/aws/variables.tf
@@ -4,6 +4,12 @@ variable "region" {
     default = "us-east-1"
 }
 variable "env_name" {}
+variable "build_id" {}
+variable "build_name" {}
+variable "build_job_name" {}
+variable "build_pipeline_name" {}
+variable "build_team_name" {}
+variable "atc_external_url" {}
 
 variable "bucket" {}
 variable "object_key" {}

--- a/fixtures/module/module.tf
+++ b/fixtures/module/module.tf
@@ -6,6 +6,14 @@ module "test_module" {
   region = "${var.region}"
   env_name = "${var.env_name}"
 
+  env_name = "${var.env_name}"
+  build_id = "${var.build_id}"
+  build_name = "${var.build_name}"
+  build_job_name = "${var.build_job_name}"
+  build_pipeline_name = "${var.build_pipeline_name}"
+  build_team_name = "${var.build_team_name}"
+  atc_external_url = "${var.atc_external_url}"
+
   bucket = "${var.bucket}"
   object_key = "${var.object_key}"
   object_content = "${var.object_content}"

--- a/fixtures/module/module.tf
+++ b/fixtures/module/module.tf
@@ -6,7 +6,6 @@ module "test_module" {
   region = "${var.region}"
   env_name = "${var.env_name}"
 
-  env_name = "${var.env_name}"
   build_id = "${var.build_id}"
   build_name = "${var.build_name}"
   build_job_name = "${var.build_job_name}"

--- a/fixtures/module/variables.tf
+++ b/fixtures/module/variables.tf
@@ -4,6 +4,12 @@ variable "region" {
     default = "us-east-1"
 }
 variable "env_name" {}
+variable "build_id" {}
+variable "build_name" {}
+variable "build_job_name" {}
+variable "build_pipeline_name" {}
+variable "build_team_name" {}
+variable "atc_external_url" {}
 
 variable "bucket" {}
 variable "object_key" {}

--- a/src/terraform-resource/out/out.go
+++ b/src/terraform-resource/out/out.go
@@ -65,6 +65,12 @@ func (r Runner) Run(req models.OutRequest) (models.OutResponse, error) {
 		return models.OutResponse{}, err
 	}
 	terraformModel.Vars["env_name"] = envName
+	terraformModel.Vars["build_id"] = os.Getenv("BUILD_ID")
+	terraformModel.Vars["build_name"] = os.Getenv("BUILD_NAME")
+	terraformModel.Vars["build_job_name"] = os.Getenv("BUILD_JOB_NAME")
+	terraformModel.Vars["build_pipeline_name"] = os.Getenv("BUILD_PIPELINE_NAME")
+	terraformModel.Vars["build_team_name"] = os.Getenv("BUILD_TEAM_NAME")
+	terraformModel.Vars["atc_external_url"] = os.Getenv("ATC_EXTERNAL_URL")
 
 	terraformModel.PlanFileLocalPath = path.Join(tmpDir, "plan")
 	terraformModel.PlanFileRemotePath = fmt.Sprintf("%s.plan", envName)

--- a/src/terraform-resource/out/out_test.go
+++ b/src/terraform-resource/out/out_test.go
@@ -268,7 +268,6 @@ var _ = Describe("Out", func() {
 			"atc_external_url": "sample-atc-external-url",
 			"content_md5": calculateMD5("terraform-is-neat"),
 		}
-		fmt.Println(req)
 		assertOutBehavior(req, expectedMetadata)
 
 		awsVerifier.ExpectS3FileToExist(bucket, s3ObjectPath)

--- a/src/terraform-resource/out/out_test.go
+++ b/src/terraform-resource/out/out_test.go
@@ -49,6 +49,13 @@ var _ = Describe("Out", func() {
 		stateFilePath = path.Join(bucketPath, fmt.Sprintf("%s.tfstate", envName))
 		s3ObjectPath = path.Join(bucketPath, helpers.RandomString("out-test"))
 
+		os.Setenv("BUILD_ID", "sample-build-id")
+		os.Setenv("BUILD_NAME", "sample-build-name")
+		os.Setenv("BUILD_JOB_NAME", "sample-build-job-name")
+		os.Setenv("BUILD_PIPELINE_NAME", "sample-build-pipeline-name")
+		os.Setenv("BUILD_TEAM_NAME", "sample-build-team-name")
+		os.Setenv("ATC_EXTERNAL_URL", "sample-atc-external-url")
+
 		storageModel = storage.Model{
 			Bucket:          bucket,
 			BucketPath:      bucketPath,
@@ -230,6 +237,43 @@ var _ = Describe("Out", func() {
 
 		assertOutBehavior(req, expectedMetadata)
 	})
+
+	It("creates build information as variables", func() {
+		req := models.OutRequest{
+			Source: models.Source{
+				Storage: storageModel,
+			},
+			Params: models.OutParams{
+				EnvName: envName,
+				Terraform: models.Terraform{
+					Source: "fixtures/aws/",
+					Vars: map[string]interface{}{
+						"access_key":     accessKey,
+						"secret_key":     secretKey,
+						"bucket":         bucket,
+						"object_key":     s3ObjectPath,
+						"object_content": "terraform-is-neat",
+						"region":         region,
+					},
+				},
+			},
+		}
+		expectedMetadata := map[string]string{
+			"env_name":    envName,
+			"build_id": "sample-build-id",
+			"build_name": "sample-build-name",
+			"build_job_name": "sample-build-job-name",
+			"build_pipeline_name": "sample-build-pipeline-name",
+			"build_team_name": "sample-build-team-name",
+			"atc_external_url": "sample-atc-external-url",
+			"content_md5": calculateMD5("terraform-is-neat"),
+		}
+		fmt.Println(req)
+		assertOutBehavior(req, expectedMetadata)
+
+		awsVerifier.ExpectS3FileToExist(bucket, s3ObjectPath)
+	})
+
 
 	Context("when given a yaml file containing variables", func() {
 		var firstVarFile string


### PR DESCRIPTION
Some build information like build_id, pipeline_name, etc are available
as environment variables in container environment. These are exposed
as terraform variables

More details in https://github.com/ljfranklin/terraform-resource/issues/36