### PR TITLE
support optional plugin_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Finally, `env_name` is automatically passed as an input `var`.
 
   > **Note:** You must also set `put.get_params.action` to `destroy` to ensure the task succeeds. This is a temporary workaround until Concourse adds support for `delete` as a first-class operation. See [this issue](https://github.com/concourse/concourse/issues/362) for more details.
 
+* `plugin_dir`: *Optional.* The relative path of the directory containing any third-party terraform plugins you wish to install. See [https://www.terraform.io/docs/configuration/providers.html#third-party-plugins](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins) for more information. NOTE: the terraform CLI *will not* fetch plugins automatically if this is flag is provided. Therefore you must ensure that all required plugins are placed in this directory if you use this flag, whether they are third-party or not. The standard Hashicorp plugins can be found at https://releases.hashicorp.com/.
+
 #### Put Example
 
 ```yaml

--- a/src/terraform-resource/models/terraform.go
+++ b/src/terraform-resource/models/terraform.go
@@ -18,6 +18,7 @@ type Terraform struct {
 	PlanRun             bool                   `json:"plan_run,omitempty"`          // optional
 	OutputModule        string                 `json:"output_module,omitempty"`     // optional
 	ImportFiles         []string               `json:"import_files,omitempty"`      // optional
+	PluginDir           string                 `json:"plugin_dir,omitempty"`        // optional
 	PlanFileLocalPath   string                 `json:"-"`                           // not specified pipeline
 	PlanFileRemotePath  string                 `json:"-"`                           // not specified pipeline
 	StateFileLocalPath  string                 `json:"-"`                           // not specified pipeline
@@ -101,6 +102,10 @@ func (m Terraform) Merge(other Terraform) Terraform {
 
 	if other.ImportFiles != nil {
 		m.ImportFiles = other.ImportFiles
+	}
+
+	if other.PluginDir != "" {
+		m.PluginDir = other.PluginDir
 	}
 
 	if other.Imports != nil {

--- a/src/terraform-resource/models/terraform_test.go
+++ b/src/terraform-resource/models/terraform_test.go
@@ -95,6 +95,7 @@ var _ = Describe("Terraform Models", func() {
 				DeleteOnFailure:     true,
 				ImportFiles:         []string{"fake-imports-path"},
 				Imports:             map[string]string{"fake-key": "fake-value"},
+				PluginDir:           "fake-plugin-path",
 			}
 
 			finalModel := baseModel.Merge(mergeModel)
@@ -104,6 +105,7 @@ var _ = Describe("Terraform Models", func() {
 			Expect(finalModel.DeleteOnFailure).To(BeTrue())
 			Expect(finalModel.ImportFiles).To(Equal([]string{"fake-imports-path"}))
 			Expect(finalModel.Imports).To(Equal(map[string]string{"fake-key": "fake-value"}))
+			Expect(finalModel.PluginDir).To(Equal("fake-plugin-path"))
 		})
 
 		It("returns original vars and vars from Merged model", func() {

--- a/src/terraform-resource/out/out_custom_plugins_test.go
+++ b/src/terraform-resource/out/out_custom_plugins_test.go
@@ -1,0 +1,271 @@
+package out_test
+
+import (
+	"archive/zip"
+	"crypto/md5"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+
+	"terraform-resource/models"
+	"terraform-resource/out"
+	"terraform-resource/storage"
+	"terraform-resource/test/helpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Out Lifecycle with Custom Plugins", func() {
+
+	var (
+		envName       string
+		stateFilePath string
+		planFilePath  string
+		s3ObjectPath  string
+		workingDir    string
+		pluginDir     string
+	)
+
+	BeforeEach(func() {
+		envName = helpers.RandomString("out-test")
+		stateFilePath = path.Join(bucketPath, fmt.Sprintf("%s.tfstate", envName))
+		planFilePath = path.Join(bucketPath, fmt.Sprintf("%s.plan", envName))
+		s3ObjectPath = path.Join(bucketPath, helpers.RandomString("out-lifecycle"))
+
+		var err error
+		workingDir, err = ioutil.TempDir(os.TempDir(), "terraform-resource-out-test")
+		Expect(err).ToNot(HaveOccurred())
+
+		pluginDir, err = ioutil.TempDir(os.TempDir(), "terraform-resource-out-test-plugins")
+		Expect(err).ToNot(HaveOccurred())
+
+		awsProviderURL := fmt.Sprintf("https://releases.hashicorp.com/terraform-provider-aws/1.2.0/terraform-provider-aws_1.2.0_%s_%s.zip", runtime.GOOS, runtime.GOARCH)
+		err = downloadPlugins(pluginDir, awsProviderURL)
+		Expect(err).ToNot(HaveOccurred())
+
+		// ensure relative paths resolve correctly
+		err = os.Chdir(workingDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		fixturesDir := path.Join(helpers.ProjectRoot(), "fixtures")
+		err = exec.Command("cp", "-r", fixturesDir, workingDir).Run()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(workingDir)
+		_ = os.RemoveAll(pluginDir)
+		awsVerifier.DeleteObjectFromS3(bucket, s3ObjectPath)
+		awsVerifier.DeleteObjectFromS3(bucket, stateFilePath)
+		awsVerifier.DeleteObjectFromS3(bucket, planFilePath)
+	})
+
+	It("plan infrastructure and apply it", func() {
+		planOutRequest := models.OutRequest{
+			Source: models.Source{
+				Storage: storage.Model{
+					Bucket:          bucket,
+					BucketPath:      bucketPath,
+					AccessKeyID:     accessKey,
+					SecretAccessKey: secretKey,
+					RegionName:      region,
+				},
+			},
+			Params: models.OutParams{
+				EnvName: envName,
+				Terraform: models.Terraform{
+					Source:    "fixtures/aws/",
+					PluginDir: pluginDir,
+					PlanOnly:  true,
+					Vars: map[string]interface{}{
+						"access_key":     accessKey,
+						"secret_key":     secretKey,
+						"bucket":         bucket,
+						"object_key":     s3ObjectPath,
+						"object_content": "terraform-is-neat",
+						"region":         region,
+					},
+				},
+			},
+		}
+
+		applyRequest := models.OutRequest{
+			Source: models.Source{
+				Storage: storage.Model{
+					Bucket:          bucket,
+					BucketPath:      bucketPath,
+					AccessKeyID:     accessKey,
+					SecretAccessKey: secretKey,
+					RegionName:      region,
+				},
+			},
+			Params: models.OutParams{
+				EnvName: envName,
+				Terraform: models.Terraform{
+					PlanRun: true,
+				},
+			},
+		}
+
+		By("running 'out' to create the plan file")
+
+		planrunner := out.Runner{
+			SourceDir: workingDir,
+			LogWriter: GinkgoWriter,
+		}
+		_, err := planrunner.Run(planOutRequest)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("ensuring state file does not already exist")
+
+		awsVerifier.ExpectS3FileToNotExist(
+			applyRequest.Source.Storage.Bucket,
+			stateFilePath,
+		)
+
+		By("applying the plan")
+
+		applyrunner := out.Runner{
+			SourceDir: workingDir,
+			LogWriter: GinkgoWriter,
+		}
+		createOutput, err := applyrunner.Run(applyRequest)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(createOutput.Version.PlanOnly).To(BeEmpty())
+
+		Expect(createOutput.Metadata).ToNot(BeEmpty())
+		fields := map[string]interface{}{}
+		for _, field := range createOutput.Metadata {
+			fields[field.Name] = field.Value
+		}
+		Expect(fields["env_name"]).To(Equal(envName))
+		expectedMD5 := fmt.Sprintf("%x", md5.Sum([]byte("terraform-is-neat")))
+		Expect(fields["content_md5"]).To(Equal(expectedMD5))
+
+		awsVerifier.ExpectS3FileToExist(
+			applyRequest.Source.Storage.Bucket,
+			s3ObjectPath,
+		)
+	})
+
+	It("creates, updates, and deletes infrastructure", func() {
+		outRequest := models.OutRequest{
+			Source: models.Source{
+				Storage: storage.Model{
+					Bucket:          bucket,
+					BucketPath:      bucketPath,
+					AccessKeyID:     accessKey,
+					SecretAccessKey: secretKey,
+					RegionName:      region,
+				},
+			},
+			Params: models.OutParams{
+				EnvName: envName,
+				Terraform: models.Terraform{
+					PluginDir: pluginDir,
+					Source:    "fixtures/aws/",
+					Vars: map[string]interface{}{
+						"access_key":     accessKey,
+						"secret_key":     secretKey,
+						"bucket":         bucket,
+						"object_key":     s3ObjectPath,
+						"object_content": "terraform-is-neat",
+						"region":         region,
+					},
+				},
+			},
+		}
+
+		By("running 'out' to create the S3 file")
+
+		runner := out.Runner{
+			SourceDir: workingDir,
+			LogWriter: GinkgoWriter,
+		}
+		createOutput, err := runner.Run(outRequest)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(createOutput.Metadata).ToNot(BeEmpty())
+		fields := map[string]interface{}{}
+		for _, field := range createOutput.Metadata {
+			fields[field.Name] = field.Value
+		}
+		Expect(fields["env_name"]).To(Equal(envName))
+		expectedMD5 := fmt.Sprintf("%x", md5.Sum([]byte("terraform-is-neat")))
+		Expect(fields["content_md5"]).To(Equal(expectedMD5))
+
+		awsVerifier.ExpectS3FileToExist(
+			outRequest.Source.Storage.Bucket,
+			s3ObjectPath,
+		)
+
+		By("running 'out' to delete the S3 file")
+
+		outRequest.Params.Action = models.DestroyAction
+		_, err = runner.Run(outRequest)
+		Expect(err).ToNot(HaveOccurred())
+
+		awsVerifier.ExpectS3FileToNotExist(
+			outRequest.Source.Storage.Bucket,
+			s3ObjectPath,
+		)
+	})
+})
+
+func downloadPlugins(pluginPath string, url string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	zipFile, err := ioutil.TempFile("", "terraform-resource-out-test")
+	if err != nil {
+		return err
+	}
+	defer zipFile.Close()
+
+	if _, err := io.Copy(zipFile, resp.Body); err != nil {
+		return err
+	}
+
+	zipReader, err := zip.OpenReader(zipFile.Name())
+	if err != nil {
+		return err
+	}
+	defer zipReader.Close()
+
+	for _, sourceFile := range zipReader.File {
+		path := filepath.Join(pluginPath, sourceFile.Name)
+
+		reader, err := sourceFile.Open()
+		if err != nil {
+			return err
+		}
+		defer reader.Close()
+
+		writer, err := os.Create(path)
+		if err != nil {
+			return err
+		}
+		defer writer.Close()
+
+		if _, err := io.Copy(writer, reader); err != nil {
+			return err
+		}
+
+		if err := os.Chmod(path, 0700); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/src/terraform-resource/terraform/client.go
+++ b/src/terraform-resource/terraform/client.go
@@ -228,13 +228,21 @@ func (c Client) terraformCmd(args []string) *exec.Cmd {
 }
 
 func (c Client) runInit() error {
-	initCmd := c.terraformCmd([]string{
+	initArgs := []string{
 		"init",
 		"-input=false",
 		"-get=true",
 		"-backend=false", // resource doesn't support built-in backends yet
-		c.Model.Source,
-	})
+	}
+
+	if c.Model.PluginDir != "" {
+		initArgs = append(initArgs, fmt.Sprintf("-plugin-dir=%s", c.Model.PluginDir))
+	}
+
+	initArgs = append(initArgs, c.Model.Source)
+
+	initCmd := c.terraformCmd(initArgs)
+
 	if output, err := initCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("terraform init command failed.\nError: %s\nOutput: %s", err, output)
 	}


### PR DESCRIPTION
This adds an optional parameter to the PUT operation that allows you to specify a local plugin dir which is useful if you want to use third-party plugins.

Note that (annoyingly) terraform will not allow you to use _both_ a local plugin dir (using `-plugin-dir` and fetch plugins from the internet (using `-get-plugins=true`). If you specify `-plugin-dir`, it will ignore `-get-plugins=true` and fail if _any_ required plugins are missing. This means that to use this parameter, you have to go and download all your standard plugins from https://releases.hashicorp.com/ as well as the third-party plugins you wanted to use.

This is terrible UX so feel free to reject the PR on those grounds :) — Sadly I don't have an option as I need to use third-party plugins so am making this PR in case you want this feature. I've tested it and am using it as part of my current CI pipelines.