### PR TITLE
Enable (some) Glibc linked providers to run

### DIFF
--- a/docker-dev/Dockerfile
+++ b/docker-dev/Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:1.9-alpine
 
 RUN apk update && \
-   apk --no-cache add ca-certificates git bash wget gnupg unzip make
+   apk --no-cache add ca-certificates git bash wget gnupg unzip make \
+                      libc6-compat
 
 # install go deps
 RUN go get github.com/onsi/ginkgo/ginkgo

--- a/docker-prod/Dockerfile
+++ b/docker-prod/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 RUN apk update && \
-    apk add ca-certificates git bash
+    apk add ca-certificates git bash libc6-compat
 
 COPY terraform/* /usr/local/bin/
 COPY check in out /opt/resource/


### PR DESCRIPTION
Alpine Linux (the base image for this resource) uses musl libc, which
some providers (e.g. http://github.com/mevansam/terraform-provider-cf)
won't run against.

Whilst this could be fixed by static compilation on a provider by
provider basis, some can be fixed by using the Alpine library:

https://pkgs.alpinelinux.org/package/edge/main/x86/libc6-compat

which adds approximately 8kb to the final image size.