### PR TITLE
Add support for IAM instance profile auth for S3 storage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ See [DEVELOPMENT](DEVELOPMENT.md) if you're interested in submitting a PR :+1:
 
 * `storage.secret_access_key`: *Required.* The AWS secret key used to access the bucket.
 
+* `storage.use_ec2_role`: *Optional.* Set to `true` to use IAM instance profiles instead of static credentials for S3 storage.
+
 * `storage.region_name`: *Optional.* The AWS region where the bucket is located.
 
 * `storage.server_side_encryption`: *Optional.* An encryption algorithm to use when storing objects in S3, e.g. "AES256".

--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ See [DEVELOPMENT](DEVELOPMENT.md) if you're interested in submitting a PR :+1:
 
 * `storage.bucket_path`: *Required.* The S3 path used to store state files, e.g. `terraform-ci/`.
 
-* `storage.access_key_id`: *Required.* The AWS access key used to access the bucket.
+* `storage.access_key_id`: *Optional.* The AWS access key used to access the bucket.
 
-* `storage.secret_access_key`: *Required.* The AWS secret key used to access the bucket.
+* `storage.secret_access_key`: *Optional.* The AWS secret key used to access the bucket.
 
-* `storage.use_ec2_role`: *Optional.* Set to `true` to use IAM instance profiles instead of static credentials for S3 storage.
+  > **Note:** `access_key_id` and `secret_access_key` are required if `use_ec2_role` is set to false.
+
+* `storage.use_ec2_role`: *Optional. Default `false`.* If true use IAM instance profiles instead of static credentials for S3 storage.
 
 * `storage.region_name`: *Optional.* The AWS region where the bucket is located.
 

--- a/src/terraform-resource/storage/models.go
+++ b/src/terraform-resource/storage/models.go
@@ -18,6 +18,7 @@ type Model struct {
 	BucketPath           string `json:"bucket_path"`
 	AccessKeyID          string `json:"access_key_id"`
 	SecretAccessKey      string `json:"secret_access_key"`
+	UseEC2Role           bool   `json:"use_ec2_role"`
 	RegionName           string `json:"region_name,omitempty"`            // optional
 	Endpoint             string `json:"endpoint,omitempty"`               // optional
 	UseSigningV2         bool   `json:"use_signing_v2,omitempty"`         // optional
@@ -65,11 +66,13 @@ func (m Model) Validate() error {
 		if m.BucketPath == "" {
 			missingFields = append(missingFields, fmt.Sprintf("%s.bucket_path", fieldPrefix))
 		}
-		if m.AccessKeyID == "" {
-			missingFields = append(missingFields, fmt.Sprintf("%s.access_key_id", fieldPrefix))
-		}
-		if m.SecretAccessKey == "" {
-			missingFields = append(missingFields, fmt.Sprintf("%s.secret_access_key", fieldPrefix))
+		if !m.UseEC2Role {
+			if m.AccessKeyID == "" {
+				missingFields = append(missingFields, fmt.Sprintf("%s.access_key_id", fieldPrefix))
+			}
+			if m.SecretAccessKey == "" {
+				missingFields = append(missingFields, fmt.Sprintf("%s.secret_access_key", fieldPrefix))
+			}
 		}
 	}
 


### PR DESCRIPTION
When using a Concourse deployed to AWS to use this resource you are likely to want to use IAM instance profiles in place of static credentials.

This PR adds a new configuration option of `use_ec2_role` that will override static credentials when set to `true`. It does not change the default behaviour.