### PR TITLE
Adding IAM role cred chain.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg/
 credentials.yml
 /out/
 *.swp
+.idea

--- a/src/terraform-resource/storage/models.go
+++ b/src/terraform-resource/storage/models.go
@@ -65,12 +65,6 @@ func (m Model) Validate() error {
 		if m.BucketPath == "" {
 			missingFields = append(missingFields, fmt.Sprintf("%s.bucket_path", fieldPrefix))
 		}
-		if m.AccessKeyID == "" {
-			missingFields = append(missingFields, fmt.Sprintf("%s.access_key_id", fieldPrefix))
-		}
-		if m.SecretAccessKey == "" {
-			missingFields = append(missingFields, fmt.Sprintf("%s.secret_access_key", fieldPrefix))
-		}
 	}
 
 	if len(missingFields) > 0 {

--- a/src/terraform-resource/test/helpers/aws_verifier.go
+++ b/src/terraform-resource/test/helpers/aws_verifier.go
@@ -24,18 +24,24 @@ func NewAWSVerifier(accessKey string, secretKey string, region string, endpoint 
 	if len(region) == 0 {
 		region = " " // aws sdk complains if region is empty
 	}
+
 	awsConfig := &aws.Config{
 		Region:           aws.String(region),
-		Credentials:      credentials.NewStaticCredentials(accessKey, secretKey, ""),
 		S3ForcePathStyle: aws.Bool(true),
 		MaxRetries:       aws.Int(10),
 	}
+
+	if accessKey != "" && secretKey != "" {
+		awsConfig.Credentials = credentials.NewStaticCredentials(accessKey, secretKey, "")
+	}
+
 	if len(endpoint) > 0 {
 		awsConfig.Endpoint = aws.String(endpoint)
 	}
 
-	ec2 := awsec2.New(awsSession.New(awsConfig))
-	s3 := awss3.New(awsSession.New(awsConfig))
+	session := awsSession.Must(awsSession.NewSession())
+	ec2 := awsec2.New(session, awsConfig)
+	s3 := awss3.New(session, awsConfig)
 	if len(endpoint) > 0 {
 		// many s3-compatible endpoints only support v2 signing
 		storage.Setv2Handlers(s3)


### PR DESCRIPTION
In order to make this happen we need to remove the validation bits from the storage model. I don't think there's a good way to support that and use the default cred chain which will allow people with IAM roles in place to skip the key bits when defining the resource. I like this better because otherwise you have to create a user and distribute keys in a secure manner (usually via vault)--the IAM role is a best practice in AWS land.

I have a working version of this container running in production for our clients.

7factor/terraform-resource