### PR TITLE
destination directory for a terraform override file [WIP-tf-backends]

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,10 @@ Finally, `env_name` is automatically passed as an input `var`.
 
 * `override_files`: *Optional.* A list of files to copy into the `terraform_source` directory. Override files must follow conventions outlined [here](https://www.terraform.io/docs/configuration/override.html) such as file names ending in `_override.tf`.
 
-* `action`: *Optional.* When set to `destroy`, the resource will run `terraform destroy` against the given statefile.
+* `module_override_files`: *Optional.* A list of maps to copy override files to specific destination directories. Override files must follow conventions outlined [here](https://www.terraform.io/docs/configuration/override.html) such as file names ending in `_override.tf`.
+The source file is specified with `src` and the destination directory with `dst`. 
 
+* `action`: *Optional.* When set to `destroy`, the resource will run `terraform destroy` against the given statefile.
   > **Note:** You must also set `put.get_params.action` to `destroy` to ensure the task succeeds. This is a temporary workaround until Concourse adds support for `delete` as a first-class operation. See [this issue](https://github.com/concourse/concourse/issues/362) for more details.
 
 * `plugin_dir`: *Optional.* The path (relative to your `terraform_source`) of the directory containing plugin binaries. This overrides the default plugin directory and Terraform will not automatically fetch built-in plugins if this option is used. To preserve the automatic fetching of plugins, omit `plugin_dir` and place third-party plugins in `${terraform_source}/terraform.d/plugins`. See https://www.terraform.io/docs/configuration/providers.html#third-party-plugins for more information.

--- a/src/terraform-resource/models/terraform.go
+++ b/src/terraform-resource/models/terraform.go
@@ -11,15 +11,16 @@ import (
 
 type Terraform struct {
 	Source              string                 `json:"terraform_source"`
-	Vars                map[string]interface{} `json:"vars,omitempty"`              // optional
-	VarFiles            []string               `json:"var_files,omitempty"`         // optional
-	Env                 map[string]string      `json:"env,omitempty"`               // optional
-	DeleteOnFailure     bool                   `json:"delete_on_failure,omitempty"` // optional
-	PlanOnly            bool                   `json:"plan_only,omitempty"`         // optional
-	PlanRun             bool                   `json:"plan_run,omitempty"`          // optional
-	OutputModule        string                 `json:"output_module,omitempty"`     // optional
-	ImportFiles         []string               `json:"import_files,omitempty"`      // optional
-	OverrideFiles       []string               `json:"override_files,omitempty"`    // optional
+	Vars                map[string]interface{} `json:"vars,omitempty"`              		// optional
+	VarFiles            []string               `json:"var_files,omitempty"`         		// optional
+	Env                 map[string]string      `json:"env,omitempty"`               		// optional
+	DeleteOnFailure     bool                   `json:"delete_on_failure,omitempty"` 		// optional
+	PlanOnly            bool                   `json:"plan_only,omitempty"`         		// optional
+	PlanRun             bool                   `json:"plan_run,omitempty"`          		// optional
+	OutputModule        string                 `json:"output_module,omitempty"`     		// optional
+	ImportFiles         []string               `json:"import_files,omitempty"`      		// optional
+	OverrideFiles       []string               `json:"override_files,omitempty"`    		// optional
+	ModuleOverrideFiles []map[string]string    `json:"module_override_files,omitempty"`		// optional
 	PluginDir           string                 `json:"plugin_dir,omitempty"`        // optional
 	BackendType         string                 `json:"backend_type,omitempty"`      // optional
 	BackendConfig       map[string]interface{} `json:"backend_config,omitempty"`    // optional
@@ -105,6 +106,10 @@ func (m Terraform) Merge(other Terraform) Terraform {
 	if other.OverrideFiles != nil {
 		m.OverrideFiles = other.OverrideFiles
 	}
+
+	if other.ModuleOverrideFiles != nil {
+		m.ModuleOverrideFiles = other.ModuleOverrideFiles
+	}	
 
 	if other.PluginDir != "" {
 		m.PluginDir = other.PluginDir

--- a/src/terraform-resource/models/terraform_test.go
+++ b/src/terraform-resource/models/terraform_test.go
@@ -83,6 +83,7 @@ var _ = Describe("Terraform Models", func() {
 				DeleteOnFailure:     true,
 				ImportFiles:         []string{"fake-imports-path"},
 				OverrideFiles:       []string{"fake-override-path"},
+				ModuleOverrideFiles: []map[string]string{ map[string]string{"src": "fake-override-src-path", "dst" : "fake-override-dst-path",}, },
 				Imports:             map[string]string{"fake-key": "fake-value"},
 				PluginDir:           "fake-plugin-path",
 				BackendType:         "fake-type",
@@ -96,6 +97,7 @@ var _ = Describe("Terraform Models", func() {
 			Expect(finalModel.DeleteOnFailure).To(BeTrue())
 			Expect(finalModel.ImportFiles).To(Equal([]string{"fake-imports-path"}))
 			Expect(finalModel.OverrideFiles).To(Equal([]string{"fake-override-path"}))
+			Expect(finalModel.ModuleOverrideFiles).To(Equal([]map[string]string{ map[string]string{"src": "fake-override-src-path", "dst" : "fake-override-dst-path"}}))
 			Expect(finalModel.Imports).To(Equal(map[string]string{"fake-key": "fake-value"}))
 			Expect(finalModel.PluginDir).To(Equal("fake-plugin-path"))
 			Expect(finalModel.BackendType).To(Equal("fake-type"))

--- a/src/terraform-resource/out/out_module_override_test.go
+++ b/src/terraform-resource/out/out_module_override_test.go
@@ -1,0 +1,363 @@
+package out_test
+
+import (
+	"crypto/md5"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+
+	"terraform-resource/models"
+	"terraform-resource/out"
+	"terraform-resource/test/helpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Out Module Override", func() {
+
+	var (
+		envName       string
+		stateFilePath string
+		s3ObjectPath  string
+		workspacePath string
+		workingDir    string
+	)
+
+	BeforeEach(func() {
+		envName = helpers.RandomString("out-test")
+		stateFilePath = path.Join(bucketPath, fmt.Sprintf("%s.tfstate", envName))
+		s3ObjectPath = path.Join(bucketPath, helpers.RandomString("out-import"))
+
+		var err error
+		workingDir, err = ioutil.TempDir(os.TempDir(), "terraform-resource-out-import-test")
+		Expect(err).ToNot(HaveOccurred())
+
+		// ensure relative paths resolve correctly
+		err = os.Chdir(workingDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		fixturesDir := path.Join(helpers.ProjectRoot(), "fixtures")
+		err = exec.Command("cp", "-r", fixturesDir, workingDir).Run()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(workingDir)
+		awsVerifier.DeleteObjectFromS3(bucket, s3ObjectPath)
+		awsVerifier.DeleteObjectFromS3(bucket, stateFilePath)
+	})
+
+	It("overrides the existing resource definition in module", func() {
+		req := models.OutRequest{
+			Source: models.Source{
+				Terraform: models.Terraform{
+					BackendType: "s3",
+					BackendConfig: map[string]interface{}{
+						"bucket":               bucket,
+						"key":                  "terraform.tfstate",
+						"access_key":           accessKey,
+						"secret_key":           secretKey,
+						"region":               region,
+						"workspace_key_prefix": workspacePath,
+					},
+				},
+			},
+			Params: models.OutParams{
+				EnvName: envName,
+				Terraform: models.Terraform{
+					ModuleOverrideFiles: []map[string]string{ map[string]string{"src": "fixtures/override/example_override.tf", "dst" : "fixtures/aws",}, },
+					Source: "fixtures/module/",
+					Vars: map[string]interface{}{
+						"access_key":     accessKey,
+						"secret_key":     secretKey,
+						"bucket":         bucket,
+						"object_key":     s3ObjectPath,
+						"object_content": "terraform-is-neat",
+						"region":         region,
+					},
+				},
+			},
+		}
+
+		runner := out.Runner{
+			SourceDir: workingDir,
+			LogWriter: GinkgoWriter,
+		}
+
+		output, err := runner.Run(req)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(output.Metadata).ToNot(BeEmpty())
+		fields := map[string]interface{}{}
+		for _, field := range output.Metadata {
+			fields[field.Name] = field.Value
+		}
+		Expect(fields["env_name"]).To(Equal(envName))
+		Expect(fields["object_content"]).To(Equal("OVERRIDE"))
+		expectedMD5 := fmt.Sprintf("%x", md5.Sum([]byte("OVERRIDE")))
+		Expect(fields["content_md5"]).To(Equal(expectedMD5))
+
+		awsVerifier.ExpectS3FileToExist(bucket, s3ObjectPath)
+	})
+
+	It("errors when given a directory for source", func() {
+		req := models.OutRequest{
+			Source: models.Source{
+				Terraform: models.Terraform{
+					BackendType: "s3",
+					BackendConfig: map[string]interface{}{
+						"bucket":               bucket,
+						"key":                  "terraform.tfstate",
+						"access_key":           accessKey,
+						"secret_key":           secretKey,
+						"region":               region,
+						"workspace_key_prefix": workspacePath,
+					},
+				},
+			},
+			Params: models.OutParams{
+				EnvName: envName,
+				Terraform: models.Terraform{
+					ModuleOverrideFiles: []map[string]string{ map[string]string{"src": "fixtures/override/", "dst" : "fixtures/aws",}, },
+					Source: "fixtures/module/",
+					Vars: map[string]interface{}{
+						"access_key":     accessKey,
+						"secret_key":     secretKey,
+						"bucket":         bucket,
+						"object_key":     s3ObjectPath,
+						"object_content": "terraform-is-neat",
+						"region":         region,
+					},
+				},
+			},
+		}
+
+		runner := out.Runner{
+			SourceDir: workingDir,
+			LogWriter: GinkgoWriter,
+		}
+
+		_, err := runner.Run(req)
+		Expect(err).To(HaveOccurred())
+
+		Expect(err.Error()).To(ContainSubstring("override source 'fixtures/override/' is as directory, must pass files instead"))
+	})
+
+	It("errors when given a file for destination", func() {
+		req := models.OutRequest{
+			Source: models.Source{
+				Terraform: models.Terraform{
+					BackendType: "s3",
+					BackendConfig: map[string]interface{}{
+						"bucket":               bucket,
+						"key":                  "terraform.tfstate",
+						"access_key":           accessKey,
+						"secret_key":           secretKey,
+						"region":               region,
+						"workspace_key_prefix": workspacePath,
+					},
+				},
+			},
+			Params: models.OutParams{
+				EnvName: envName,
+				Terraform: models.Terraform{
+					ModuleOverrideFiles: []map[string]string{ map[string]string{"src": "fixtures/override/example_override.tf", "dst" : "fixtures/aws/example.tf",}, },
+					Source: "fixtures/module/",
+					Vars: map[string]interface{}{
+						"access_key":     accessKey,
+						"secret_key":     secretKey,
+						"bucket":         bucket,
+						"object_key":     s3ObjectPath,
+						"object_content": "terraform-is-neat",
+						"region":         region,
+					},
+				},
+			},
+		}
+
+		runner := out.Runner{
+			SourceDir: workingDir,
+			LogWriter: GinkgoWriter,
+		}
+
+		_, err := runner.Run(req)
+		Expect(err).To(HaveOccurred())
+
+		Expect(err.Error()).To(ContainSubstring("override destination 'fixtures/aws/example.tf' is a file, must pass directory instead"))
+	})
+
+	It("errors when given an invalid path for source", func() {
+		req := models.OutRequest{
+			Source: models.Source{
+				Terraform: models.Terraform{
+					BackendType: "s3",
+					BackendConfig: map[string]interface{}{
+						"bucket":               bucket,
+						"key":                  "terraform.tfstate",
+						"access_key":           accessKey,
+						"secret_key":           secretKey,
+						"region":               region,
+						"workspace_key_prefix": workspacePath,
+					},
+				},
+			},
+			Params: models.OutParams{
+				EnvName: envName,
+				Terraform: models.Terraform{
+					ModuleOverrideFiles: []map[string]string{ map[string]string{"src": "does-not-exist", "dst" : "fixtures/aws",}, },
+					Source: "fixtures/module/",
+					Vars: map[string]interface{}{
+						"access_key":     accessKey,
+						"secret_key":     secretKey,
+						"bucket":         bucket,
+						"object_key":     s3ObjectPath,
+						"object_content": "terraform-is-neat",
+						"region":         region,
+					},
+				},
+			},
+		}
+
+		runner := out.Runner{
+			SourceDir: workingDir,
+			LogWriter: GinkgoWriter,
+		}
+
+		_, err := runner.Run(req)
+		Expect(err).To(HaveOccurred())
+
+		Expect(err.Error()).To(ContainSubstring("override source file 'does-not-exist' does not exist"))
+	})
+
+	It("errors when given an invalid path for destination", func() {
+		req := models.OutRequest{
+			Source: models.Source{
+				Terraform: models.Terraform{
+					BackendType: "s3",
+					BackendConfig: map[string]interface{}{
+						"bucket":               bucket,
+						"key":                  "terraform.tfstate",
+						"access_key":           accessKey,
+						"secret_key":           secretKey,
+						"region":               region,
+						"workspace_key_prefix": workspacePath,
+					},
+				},
+			},
+			Params: models.OutParams{
+				EnvName: envName,
+				Terraform: models.Terraform{
+					ModuleOverrideFiles: []map[string]string{ map[string]string{"src": "fixtures/override/example_override.tf", "dst" : "does-not-exist",}, },
+					Source: "fixtures/module/",
+					Vars: map[string]interface{}{
+						"access_key":     accessKey,
+						"secret_key":     secretKey,
+						"bucket":         bucket,
+						"object_key":     s3ObjectPath,
+						"object_content": "terraform-is-neat",
+						"region":         region,
+					},
+				},
+			},
+		}
+
+		runner := out.Runner{
+			SourceDir: workingDir,
+			LogWriter: GinkgoWriter,
+		}
+
+		_, err := runner.Run(req)
+		Expect(err).To(HaveOccurred())
+
+		Expect(err.Error()).To(ContainSubstring("override destination directory 'does-not-exist' does not exist"))
+	})
+
+	It("errors when src key is missing", func() {
+		req := models.OutRequest{
+			Source: models.Source{
+				Terraform: models.Terraform{
+					BackendType: "s3",
+					BackendConfig: map[string]interface{}{
+						"bucket":               bucket,
+						"key":                  "terraform.tfstate",
+						"access_key":           accessKey,
+						"secret_key":           secretKey,
+						"region":               region,
+						"workspace_key_prefix": workspacePath,
+					},
+				},
+			},
+			Params: models.OutParams{
+				EnvName: envName,
+				Terraform: models.Terraform{
+					ModuleOverrideFiles: []map[string]string{ map[string]string{"dst" : "fixtures/aws",}, },
+					Source: "fixtures/module/",
+					Vars: map[string]interface{}{
+						"access_key":     accessKey,
+						"secret_key":     secretKey,
+						"bucket":         bucket,
+						"object_key":     s3ObjectPath,
+						"object_content": "terraform-is-neat",
+						"region":         region,
+					},
+				},
+			},
+		}
+
+		runner := out.Runner{
+			SourceDir: workingDir,
+			LogWriter: GinkgoWriter,
+		}
+
+		_, err := runner.Run(req)
+		Expect(err).To(HaveOccurred())
+
+		Expect(err.Error()).To(ContainSubstring("does not include src key"))
+	})
+
+	It("errors when dst key is missing", func() {
+		req := models.OutRequest{
+			Source: models.Source{
+				Terraform: models.Terraform{
+					BackendType: "s3",
+					BackendConfig: map[string]interface{}{
+						"bucket":               bucket,
+						"key":                  "terraform.tfstate",
+						"access_key":           accessKey,
+						"secret_key":           secretKey,
+						"region":               region,
+						"workspace_key_prefix": workspacePath,
+					},
+				},
+			},
+			Params: models.OutParams{
+				EnvName: envName,
+				Terraform: models.Terraform{
+					ModuleOverrideFiles: []map[string]string{ map[string]string{"src": "fixtures/override/example_override.tf",}, },
+					Source: "fixtures/module/",
+					Vars: map[string]interface{}{
+						"access_key":     accessKey,
+						"secret_key":     secretKey,
+						"bucket":         bucket,
+						"object_key":     s3ObjectPath,
+						"object_content": "terraform-is-neat",
+						"region":         region,
+					},
+				},
+			},
+		}
+
+		runner := out.Runner{
+			SourceDir: workingDir,
+			LogWriter: GinkgoWriter,
+		}
+
+		_, err := runner.Run(req)
+		Expect(err).To(HaveOccurred())
+
+		Expect(err.Error()).To(ContainSubstring("does not include dst key"))
+	})
+})


### PR DESCRIPTION
This implements a new option `module_override_files` to specify a list of `src`and `dst` pairs, to copy a override file to a specific directory. e.g. to override a module

Following tests are implemented:
* overrides the existing resource definition in module
* errors when given a directory for source
* errors when given a file for destination
* errors when given an invalid path for source
* errors when given an invalid path for destination
* errors when src key is missing
* errors when dst key is missing

The destination is relative to the concourse working directory to accommodate for modules being in a parent directory.

example:
```
terraform_source: fixtures/module/
module_override_files:
- src: fixtures/override/example_override.tf
  dst: fixtures/aws
```