### PR TITLE
Added support for pulling patch releases

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -382,6 +382,7 @@ jobs:
             pull_tag: test
             cache: true
             tag: resource-src/config/terraform-version
+            additional_tags: resource-src/config/terraform-major-minor
         - put: terraform-prod-image
           params:
             pull_repository: ljfranklin/terraform-resource

--- a/ci/tasks/bump-terraform-cli
+++ b/ci/tasks/bump-terraform-cli
@@ -46,6 +46,7 @@ fi
 if [[ "${upstream_patch}" -gt "${downstream_patch}" ]]; then
   echo "Bumping to new patch version '${upstream_version}'!"
   echo -n "${upstream_version}" > "${output_dir}/config/terraform-version"
+  echo -n "${upstream_major_minor}" > "${output_dir}/config/terraform-major-minor"
 else
   echo "Downstream version '${downstream_version}' is up-to-date!"
 fi


### PR DESCRIPTION
As a developer, I want to pull the latest version of the terraform-resource image that is compatible with the version of Terraform used to develop my plan so that I don't have to keep updating my pipeline when bugfix releases come out.

By using the `addtional_tags` parameter for the docker-image resource, I think pushing the image with version-specific tags can also be consolidated with the step that tags `latest`.