### PR TITLE
add `terraform-provider-vinyldns`

### DIFF
--- a/docker-prod/Dockerfile
+++ b/docker-prod/Dockerfile
@@ -11,5 +11,8 @@ RUN chmod 0600 $HOME/.ssh/config
 RUN wget -O /usr/local/bin/terraform-provider-stateful_v1.1.0-linux-amd64 \
   "https://github.com/ashald/terraform-provider-stateful/releases/download/v1.1.0/terraform-provider-stateful_v1.1.0-linux-amd64" && \
   chmod +x /usr/local/bin/terraform-provider-stateful_v1.1.0-linux-amd64
+RUN wget -O /tmp/terraform-provider-vinyldns-linux_amd64-0.9.4.tar.gz \
+  "https://github.com/vinyldns/terraform-provider-vinyldns/releases/download/0.9.4/release.terraform-provider-vinyldns-linux_amd64-0.9.4.tgz" && \
+  tar -C /usr/local/bin -xzvf /tmp/terraform-provider-vinyldns-linux_amd64-0.9.4.tar.gz
 COPY terraform/* /usr/local/bin/
 COPY check in out /opt/resource/


### PR DESCRIPTION
@ljfranklin This is a bit of a long shot -- and I completely understand if you'd rather not do this -- but this PR seeks to build the [terraform-provider-vinyldns](https://github.com/vinyldns/terraform-provider-vinyldns) into `ljfranklin/terraform-resource` such that users don't need to download it separately.

The context is...

My organization runs a very large Concourse installation serving thousands of developers. Your `ljfranklin/terraform-resource` is very popular and is in use throughout users' pipelines. However, because many, many pipelines _also_ make use of the [terraform-provider-vinyldns](https://github.com/vinyldns/terraform-provider-vinyldns), it's necessary for users to download and install the `terraform-provider-vinyldns` plugin on execution of each job that utilizes it, which tasks the pipelines in doing a lot of perhaps-avoidable work. 

For example:

```yaml
- name: terraform-apply
  serial: true
  plan:
  - in_parallel:
    - get: source
    # a github-release-resource instance:
    - get: terraform-provider-vinyldns
    # a task that copies the terraform-provider-vinyldns and .tf files to a shared location
  - task: install-tf-plugins
    file: source/ci/tasks/install_tf_plugins.yml
  - put: terraform
    params:
      terraform_source: tf-src-and-plugins
```

Before forking your resource (thanks again for all your hard work on it!), I figure I'd _at least_ open this pull request to gauge your feelings (But, as I said, I completely understand if you'd rather not merge it).

Thanks!