### PR TITLE
Replace libc6-compat with sgerrand/alpine-glibc

### DIFF
--- a/docker-dev/Dockerfile
+++ b/docker-dev/Dockerfile
@@ -6,6 +6,8 @@ RUN apk update && \
    apk --no-cache add ca-certificates git bash wget gnupg unzip make \
                       openssh-client build-base bzr@previous
 
+# this glibc compatibility module is needed for some downloaded binaries,
+# such as aws cli, to run in provisioners.
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
   wget -q -O /tmp/glibc.apk https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r0/glibc-2.32-r0.apk && \
   apk add /tmp/glibc.apk && \

--- a/docker-dev/Dockerfile
+++ b/docker-dev/Dockerfile
@@ -4,7 +4,12 @@ FROM golang:alpine
 RUN echo '@previous http://nl.alpinelinux.org/alpine/v3.11/community' >> /etc/apk/repositories
 RUN apk update && \
    apk --no-cache add ca-certificates git bash wget gnupg unzip make \
-                      libc6-compat openssh-client build-base bzr@previous
+                      openssh-client build-base bzr@previous
+
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
+  wget -q -O /tmp/glibc.apk https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r0/glibc-2.32-r0.apk && \
+  apk add /tmp/glibc.apk && \
+  rm -rf /tmp/glibc.apk
 
 # install go deps
 RUN go get github.com/onsi/ginkgo/ginkgo

--- a/docker-prod/Dockerfile
+++ b/docker-prod/Dockerfile
@@ -1,7 +1,12 @@
 FROM alpine:latest
 
 RUN apk update && \
-    apk add ca-certificates git bash libc6-compat openssh-client
+    apk add ca-certificates git bash openssh-client
+
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
+  wget -q -O /tmp/glibc.apk https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r0/glibc-2.32-r0.apk && \
+  apk add /tmp/glibc.apk && \
+  rm -rf /tmp/glibc.apk
 
 RUN mkdir -p $HOME/.ssh
 RUN echo "StrictHostKeyChecking no" >> $HOME/.ssh/config


### PR DESCRIPTION
Resolves #130 .

In order to test this change, I had to build another branch of the image which includes aws cli `FROM` this one. I expect you do not want to include that executable as well, but would be happy to add it in order to support a test somewhere like here: https://github.com/ljfranklin/terraform-resource/blob/master/fixtures/aws/example.tf#L16-L20

and additionally i wouldn't need to build new images anymore :)

AFAICT there's no other sensible place for a test for this change to live.

santé
eve