### PR TITLE
Broken link fix in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Terraform Concourse Resource
 
-A [Concourse](http://concourse.ci/) resource that allows jobs to modify IaaS resources via [Terraform](https://www.terraform.io/).
+A [Concourse](http://concourse-ci.org/) resource that allows jobs to modify IaaS resources via [Terraform](https://www.terraform.io/).
 Useful for creating a pool of reproducible environments. No more snowflakes!
 
 See [DEVELOPMENT](DEVELOPMENT.md) if you're interested in submitting a PR :+1:


### PR DESCRIPTION
Concourse CI moved their homepage a while back, i just happened to click on this link and see it was busted. Resolved here.