### PR TITLE
Merge get params Terraform config into Source config

### DIFF
--- a/src/terraform-resource/in/in.go
+++ b/src/terraform-resource/in/in.go
@@ -90,7 +90,7 @@ func (r Runner) inWithMigratedFromStorage(req models.InRequest, tmpDir string) (
 }
 
 func (r Runner) inWithBackend(req models.InRequest, tmpDir string) (models.InResponse, error) {
-	terraformModel := req.Source.Terraform
+	terraformModel := req.Source.Terraform.Merge(req.Params.Terraform)
 	if err := terraformModel.Validate(); err != nil {
 		return models.InResponse{}, fmt.Errorf("Failed to validate terraform Model: %s", err)
 	}


### PR DESCRIPTION
There may be situations where the params block contains things such as creds for accessing the statefile generated in the pipeline so not accessible in `source`. By merging the get params block into the `source`, creds can be provided at job run time

This is particularly relevant with `load_var` as we can get creds from one task in a job and interpolate them into config for future steps (such as the terraform resource). In our specific scenario we are trying to do:
```yaml
- put: our-terraform
  params:
    env:
      GOOGLE_CREDENTIALS: ((.:project-creds.gcp_credentials_json))
  get_params:
    env:
      GOOGLE_CREDENTIALS: ((.:project-creds.gcp_credentials_json))
```
but currently the implicit `get` fails as the `env` isn't actually merged in when running `in`

I wasn't sure about the tests as they seem to require creds so I just tried to copy the pattern from the `out` tests of providing bad creds in `source` and overriding them with the correct creds in the `params`. I haven't actually run the tests since they need real AWS creds.