### PR TITLE
Add curl to images

### DIFF
--- a/docker-dev/Dockerfile
+++ b/docker-dev/Dockerfile
@@ -6,7 +6,7 @@ ARG TARGETARCH
 RUN echo '@previous http://nl.alpinelinux.org/alpine/v3.11/community' >> /etc/apk/repositories
 RUN apk update && \
    apk --no-cache add ca-certificates git bash wget gnupg zip unzip make \
-                      openssh-client build-base bzr@previous
+                      openssh-client build-base bzr@previous curl
 
 # this glibc compatibility module is needed for some downloaded binaries,
 # such as aws cli, to run in provisioners.

--- a/docker-prod/Dockerfile
+++ b/docker-prod/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 ARG TARGETARCH
 
 RUN apk update && \
-    apk add ca-certificates git bash openssh-client
+    apk add ca-certificates git bash openssh-client curl
 
 # this glibc compatibility module is needed for some downloaded binaries,
 # such as aws cli, to run in provisioners.


### PR DESCRIPTION
From https://github.com/ljfranklin/terraform-resource/issues/159.

`curl` is a super valuable tool to have available for debugging and execution, as certain Terraform modules assume the tool is available on the system. `wget` is less common on systems and most tools assume the existence of `curl` before `wget`.