### PR TITLE
Refactor: Replace stateful resource with terraform_data

### DIFF
--- a/docker-prod/Dockerfile
+++ b/docker-prod/Dockerfile
@@ -32,10 +32,6 @@ RUN echo "StrictHostKeyChecking no" >> $HOME/.ssh/config
 RUN echo "LogLevel quiet" >> $HOME/.ssh/config
 RUN chmod 0600 $HOME/.ssh/config
 
-RUN mkdir -p /usr/local/share/terraform/plugins/github.com/ashald/stateful/1.2.0/linux_${TARGETARCH}/ && \
-  wget -O /usr/local/share/terraform/plugins/github.com/ashald/stateful/1.2.0/linux_${TARGETARCH}/terraform-provider-stateful_v1.2.0 \
-    "https://github.com/ashald/terraform-provider-stateful/releases/download/v1.2.0/terraform-provider-stateful_v1.2.0-linux-${TARGETARCH}" && \
-  chmod +x /usr/local/share/terraform/plugins/github.com/ashald/stateful/1.2.0/linux_${TARGETARCH}/terraform-provider-stateful_v1.2.0
 COPY $TARGETARCH/terraform/* /usr/local/bin/
 RUN terraform --version
 COPY $TARGETARCH/check $TARGETARCH/in $TARGETARCH/out /opt/resource/

--- a/src/terraform-resource/in/in_plan_test.go
+++ b/src/terraform-resource/in/in_plan_test.go
@@ -95,9 +95,6 @@ var _ = Describe("JSON Plan", func() {
 		fixturesDir := path.Join(helpers.ProjectRoot(), "fixtures")
 		err = exec.Command("cp", "-r", fixturesDir, workingDir).Run()
 		Expect(err).ToNot(HaveOccurred())
-
-		err = helpers.DownloadStatefulPlugin(workingDir)
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {

--- a/src/terraform-resource/out/out_custom_plugins_test.go
+++ b/src/terraform-resource/out/out_custom_plugins_test.go
@@ -51,14 +51,6 @@ var _ = Describe("Out Lifecycle with Custom Plugins", func() {
 		Expect(err).ToNot(HaveOccurred())
 		err = helpers.DownloadPlugins(awsPluginDir, awsProviderURL)
 		Expect(err).ToNot(HaveOccurred())
-		// In production image the stateful provider is installed in system-wide location, but manually install
-		// this plugin in plugin dir to avoid needing to run tests as root.
-		statefulProviderURL := fmt.Sprintf("https://github.com/ashald/terraform-provider-stateful/releases/download/v1.2.0/terraform-provider-stateful_v1.2.0-%s-%s.zip", runtime.GOOS, runtime.GOARCH)
-		statefulPluginDir := path.Join(pluginDir, "github.com", "ashald", "stateful", "1.2.0", fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH))
-		err = os.MkdirAll(statefulPluginDir, 0700)
-		Expect(err).ToNot(HaveOccurred())
-		err = helpers.DownloadPlugins(statefulPluginDir, statefulProviderURL)
-		Expect(err).ToNot(HaveOccurred())
 
 		// ensure relative paths resolve correctly
 		err = os.Chdir(workingDir)

--- a/src/terraform-resource/out/out_import_test.go
+++ b/src/terraform-resource/out/out_import_test.go
@@ -45,9 +45,6 @@ var _ = Describe("Out Import", func() {
 		fixturesDir := path.Join(helpers.ProjectRoot(), "fixtures")
 		err = exec.Command("cp", "-r", fixturesDir, workingDir).Run()
 		Expect(err).ToNot(HaveOccurred())
-
-		err = helpers.DownloadStatefulPlugin(workingDir)
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {

--- a/src/terraform-resource/out/out_migrated_from_storage_test.go
+++ b/src/terraform-resource/out/out_migrated_from_storage_test.go
@@ -605,11 +605,6 @@ var _ = Describe("Out - Migrated From Storage", func() {
 	})
 
 	Context("when applying a plan", func() {
-		BeforeEach(func() {
-			err := helpers.DownloadStatefulPlugin(workingDir)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
 		It("plan infrastructure and apply it", func() {
 			planRequest := models.OutRequest{
 				Source: models.Source{

--- a/src/terraform-resource/out/out_plan_test.go
+++ b/src/terraform-resource/out/out_plan_test.go
@@ -64,9 +64,6 @@ var _ = Describe("Out Plan", func() {
 		fixturesDir := path.Join(helpers.ProjectRoot(), "fixtures")
 		err = exec.Command("cp", "-r", fixturesDir, workingDir).Run()
 		Expect(err).ToNot(HaveOccurred())
-
-		err = helpers.DownloadStatefulPlugin(workingDir)
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {

--- a/src/terraform-resource/terraform/client.go
+++ b/src/terraform-resource/terraform/client.go
@@ -164,27 +164,20 @@ func (c *client) writePlanProviderConfig(outputDir string, planContents, planCon
 	}
 
 	configContents := []byte(fmt.Sprintf(`
-terraform {
-  required_providers {
-    stateful = {
-      source = "github.com/ashald/stateful"
-      version = "~> 1.0"
-    }
-  }
+resource "terraform_data" "plan_output" {
+  input = %s
 }
-resource "stateful_string" "plan_output" {
-  desired = %s
+resource "terraform_data" "plan_output_json" {
+  input = %s
 }
-resource "stateful_string" "plan_output_json" {
-  desired = %s
+
+output "%s" {
+  sensitive = true
+  value = terraform_data.plan_output.output
 }
 output "%s" {
   sensitive = true
-  value = stateful_string.plan_output.desired
-}
-output "%s" {
-  sensitive = true
-  value = stateful_string.plan_output_json.desired
+  value = terraform_data.plan_output_json.output
 }
 `, escapedPlan, escapedJSONPlan, models.PlanContent, models.PlanContentJSON))
 
@@ -758,7 +751,7 @@ func (c *client) SavePlanToBackend(planEnvName string) error {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	// TODO: this stateful set and reset isn't great
+	// TODO: this terraform_data set and reset isn't great
 	origDir, err := os.Getwd()
 	if err != nil {
 		return err

--- a/src/terraform-resource/test/helpers/plugins.go
+++ b/src/terraform-resource/test/helpers/plugins.go
@@ -2,13 +2,11 @@ package helpers
 
 import (
 	"archive/zip"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 )
 
 func DownloadPlugins(pluginPath string, url string) error {
@@ -59,41 +57,4 @@ func DownloadPlugins(pluginPath string, url string) error {
 	}
 
 	return nil
-}
-
-func DownloadStatefulPlugin(workingDir string) error {
-	var hostOS string
-	if runtime.GOOS == "darwin" {
-		hostOS = "darwin"
-	} else {
-		hostOS = "linux"
-	}
-	url := fmt.Sprintf("https://github.com/ashald/terraform-provider-stateful/releases/download/v1.2.0/terraform-provider-stateful_v1.2.0-%s-amd64", hostOS)
-
-	resp, err := http.Get(url)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	pluginDir := filepath.Join(workingDir, ".terraform.d", "plugins", "github.com",
-		"ashald", "stateful", "1.2.0", fmt.Sprintf("%s_amd64", hostOS))
-	err = os.MkdirAll(pluginDir, os.ModePerm)
-	if err != nil {
-		return err
-	}
-
-	pluginPath := filepath.Join(pluginDir, "terraform-provider-stateful_v1.2.0")
-	out, err := os.Create(pluginPath)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	if err = out.Chmod(0755); err != nil {
-		return err
-	}
-
-	_, err = io.Copy(out, resp.Body)
-	return err
 }


### PR DESCRIPTION
1. The `stateful_string` resource appears to be deprecated, so it has been replaced with the native `terraform_data` resource.
2. Using `stateful_string` with a large Terraform plan resulted in the following error:

   ``` │ Error: Plugin error │
   │   with stateful_string.plan_output,
   │   on resource_plan_config.tf line 10, in resource "stateful_string" "plan_output":
   │   10: resource "stateful_string" "plan_output" {
   │
   │ The plugin returned an unexpected error from
   │ plugin.(*GRPCProvider).PlanResourceChange: rpc error: code =
   │ ResourceExhausted desc = grpc: received message larger than max (4858459
   │ vs. 4194304)
   ```

This change ensures better compatibility and avoids hitting gRPC message size limits.